### PR TITLE
新增保持最新（订阅/配置文件）开关

### DIFF
--- a/luci-app-mihomo/htdocs/luci-static/resources/view/mihomo/config.js
+++ b/luci-app-mihomo/htdocs/luci-static/resources/view/mihomo/config.js
@@ -164,6 +164,12 @@ return view.extend({
             o.value('subscription:' + subscription['.name'], _('Subscription:') + subscription.name);
         }
 
+        o = s.option(form.Flag, 'keep_updated', _('Keep Updated'), _('Download latest subscription/file before start.'));
+        o.rmempty = false;
+        o.depends({ profile: /^subscription:/ });
+        o.depends({ profile: /^http:/ });
+        o.depends({ profile: /^https:/ });
+
         o = s.option(form.FileUpload, 'upload_profile', _('Upload Profile'));
         o.root_directory = mihomo.profilesDir;
 

--- a/luci-app-mihomo/po/zh_Hans/mihomo.po
+++ b/luci-app-mihomo/po/zh_Hans/mihomo.po
@@ -76,6 +76,12 @@ msgstr "文件："
 msgid "Subscription:"
 msgstr "订阅："
 
+msgid "Keep Updated"
+msgstr "保持最新"
+
+msgid "Download latest subscription/file before start."
+msgstr "启动前下载最新订阅/文件。"
+
 msgid "Upload Profile"
 msgstr "上传配置文件"
 

--- a/mihomo/files/mihomo.conf
+++ b/mihomo/files/mihomo.conf
@@ -6,6 +6,8 @@ config config 'config'
 	option 'scheduled_restart' '0'
 	option 'cron_expression' '0 3 * * *'
 	option 'profile' 'subscription:subscription'
+	option 'latest_profile_url' 'http://example.com/default.yaml'
+	option 'keep_updated' '1'
 	option 'mixin' '1'
 	option 'test_profile' '1'
 

--- a/mihomo/files/mihomo.init
+++ b/mihomo/files/mihomo.init
@@ -24,10 +24,12 @@ start_service() {
 	log "Starting..."
 	# get config
 	## app config
-	local scheduled_restart cron_expression profile mixin test_profile fast_reload
+	local scheduled_restart cron_expression profile latest_profile_url keep_updated mixin test_profile fast_reload
 	config_get scheduled_restart "config" "scheduled_restart"
 	config_get cron_expression "config" "cron_expression"
 	config_get profile "config" "profile"
+	config_get latest_profile_url "config" "latest_profile_url"
+	config_get_bool keep_updated "config" "keep_updated" 0
 	config_get_bool mixin "config" "mixin" 0
 	config_get_bool test_profile "config" "test_profile" 0
 	config_get_bool fast_reload "config" "fast_reload" 0
@@ -157,11 +159,19 @@ start_service() {
 				url="$url&expand=$([ "$subscription_convert_expand" == 1 ] && echo -n "true" || echo -n "false")"
 			fi
 		fi
-		curl -s -o "$RUN_PROFILE_PATH" -L -H "User-Agent: $subscription_user_agent" "$url"
+		if [[ ! -f "$RUN_PROFILE_PATH" || "$keep_updated" == 1 || "$url" != "$latest_profile_url" ]]; then
+			curl -s -o "$RUN_PROFILE_PATH" -L -H "User-Agent: $subscription_user_agent" "$url"
+			uci_set mihomo config latest_profile_url "$url"
+			uci_commit mihomo
+		fi
 		log "Use Subscription: $subscription_name"
 	elif [[ "$profile" == "http:"* || "$profile" == "https:"* ]]; then
 		local url; url=$profile
-		curl -s -o "$RUN_PROFILE_PATH" -L -H "User-Agent: mihomo clash.meta clash" "$url"
+		if [[ ! -f "$RUN_PROFILE_PATH" || "$keep_updated" == 1 || "$url" != "$latest_profile_url" ]]; then
+			curl -s -o "$RUN_PROFILE_PATH" -L -H "User-Agent: mihomo clash.meta clash" "$url"
+			uci_set mihomo config latest_profile_url "$url"
+			uci_commit mihomo
+		fi
 		log "Use Url: $url"
 	fi
 	# mixin


### PR DESCRIPTION
1. 在【基础配置】新增了一个【保持最新】开关，用于控制是否在启动时总是下载最新订阅/配置文件
2. 【保持最新】支持订阅和网络配置文件
3. 文件不存在、【保持最新】开启、订阅/配置文件url与上次不一致 时会下载，否则不会