### PR TITLE
fix(dns): dns hijack should not effect tcp

### DIFF
--- a/mihomo/files/nftables/hijack.nft
+++ b/mihomo/files/nftables/hijack.nft
@@ -75,24 +75,24 @@ table inet mihomo {
 
 	chain router_dns_hijack {
 		meta skgid @bypass_group counter return
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 oifname lo counter redirect to :$DNS_PORT
+		meta nfproto @dns_hijack_nfproto meta l4proto udp th dport 53 oifname lo counter redirect to :$DNS_PORT
 	}
 
 	chain all_dns_hijack {
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 counter redirect to :$DNS_PORT
+		meta nfproto @dns_hijack_nfproto meta l4proto udp th dport 53 counter redirect to :$DNS_PORT
 	}
 
 	chain allow_dns_hijack {
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 ip saddr @acl_ip counter redirect to :$DNS_PORT
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 ip6 saddr @acl_ip6 counter redirect to :$DNS_PORT
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 ether saddr @acl_mac counter redirect to :$DNS_PORT
+		meta nfproto @dns_hijack_nfproto meta l4proto udp th dport 53 ip saddr @acl_ip counter redirect to :$DNS_PORT
+		meta nfproto @dns_hijack_nfproto meta l4proto udp th dport 53 ip6 saddr @acl_ip6 counter redirect to :$DNS_PORT
+		meta nfproto @dns_hijack_nfproto meta l4proto udp th dport 53 ether saddr @acl_mac counter redirect to :$DNS_PORT
 	}
 
 	chain block_dns_hijack {
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 ip saddr @acl_ip counter return
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 ip6 saddr @acl_ip6 counter return
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 ether saddr @acl_mac counter return
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 counter redirect to :$DNS_PORT
+		meta nfproto @dns_hijack_nfproto meta l4proto udp th dport 53 ip saddr @acl_ip counter return
+		meta nfproto @dns_hijack_nfproto meta l4proto udp th dport 53 ip6 saddr @acl_ip6 counter return
+		meta nfproto @dns_hijack_nfproto meta l4proto udp th dport 53 ether saddr @acl_mac counter return
+		meta nfproto @dns_hijack_nfproto meta l4proto udp th dport 53 counter redirect to :$DNS_PORT
 	}
 
 	chain all_redirect {


### PR DESCRIPTION
mihomo 内核的 DNS server 不支持 tcp，所以不应劫持 tcp 53 端口的流量发送到 mihomo 的 DNS server

https://wiki.metacubex.one/config/dns/#listen

root@ImmortalWrt:~# dig @127.0.0.1 -p 1053  +tcp www.google.com ;; Connection to 127.0.0.1#1053(127.0.0.1) for www.google.com failed: connection refused. ;; no servers could be reached