### PR TITLE
Add kmod-dummy dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The package files will be found under `bin/packages/your_architecture/nikki`.
 - kmod-nft-socket
 - kmod-nft-tproxy
 - kmod-tun
+- kmod-dummy
 
 ## Contributors
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -96,6 +96,7 @@ make package/luci-app-nikki/compile
 - kmod-nft-socket
 - kmod-nft-tproxy
 - kmod-tun
+- kmod-dummy
 
 ## 贡献者
 


### PR DESCRIPTION
The kmod-dummy dependency was added in version 1.25.1, causing some versions to encounter missing dependency issues during installation. This may affect upgrades. The dependency is temporarily declared in the readme. 

See this issue https://github.com/nikkinikki-org/OpenWrt-nikki/issues/761

This dependency was included in this commit: https://github.com/nikkinikki-org/OpenWrt-nikki/commit/b5e0a5789906a2e1f6176d8f4f32fc103c7523e7