### PR TITLE
ci: add riscv64 support

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -32,6 +32,7 @@ jobs:
           - mips64_octeonplus
           - i386_pentium4
           - x86_64
+          - riscv64_riscv64
         branch:
           - openwrt-24.10
           - openwrt-25.12
@@ -41,6 +42,8 @@ jobs:
             branch: openwrt-25.12
           - arch: mips_4kec
             branch: SNAPSHOT
+          - arch: riscv64_riscv64
+            branch: openwrt-25.12
 
     steps:
       - name: checkout

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -36,6 +36,7 @@ jobs:
           - mips64_octeonplus
           - i386_pentium4
           - x86_64
+          - riscv64_riscv64
         branch:
           - openwrt-24.10
           - openwrt-25.12
@@ -45,6 +46,8 @@ jobs:
             branch: openwrt-25.12
           - arch: mips_4kec
             branch: SNAPSHOT
+          - arch: riscv64_riscv64
+            branch: openwrt-25.12
 
     steps:
       - name: checkout


### PR DESCRIPTION
ci log: [release-packages](https://github.com/panglars/OpenWrt-nikki/actions/runs/22624909474/job/65558931370)

I test package in my [VisionFive2 v1.3b](https://openwrt.org/toh/hwdata/starfive/starfive_visionfive2-v1.3b) @ immortalwrt 24.10.5 and it can run pretty well
<img width="1224" height="820" alt="image" src="https://github.com/user-attachments/assets/740b9636-8470-4129-8018-014dd7a141ae" />
